### PR TITLE
Correctly save the "Open Links in a new window" preference

### DIFF
--- a/ext/config.js
+++ b/ext/config.js
@@ -23,7 +23,7 @@ const restoreOptions = () => {
   workspace.value = localStorage["workspace"] || null;
   urlPatterns.value = localStorage["urlPatterns"] || null;
   ignoredElements.value = localStorage["ignoredElements"] || null;
-  newWindow.checked = localStorage["newWindow"] || false;
+  newWindow.checked = (localStorage["newWindow"] === "true");
 };
 
 document.addEventListener("DOMContentLoaded", restoreOptions);


### PR DESCRIPTION
localStorage stores everything as a string, so this checkbox true/false value needs to be parsed.

This should preserve (actually, fixes) the `false` default.